### PR TITLE
Add mock support for CSV file import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,4 +70,18 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>se/sundsvall/csvfilereader/file/SftpFileManager.class</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/src/main/java/se/sundsvall/csvfilereader/file/AbstractFileManager.java
+++ b/src/main/java/se/sundsvall/csvfilereader/file/AbstractFileManager.java
@@ -1,0 +1,62 @@
+package se.sundsvall.csvfilereader.file;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractFileManager implements FileManager {
+
+	private static final Logger log = LoggerFactory.getLogger(AbstractFileManager.class);
+
+	@Override
+	public void moveFile(Path targetFile, Path targetDir) {
+		try {
+			Files.createDirectories(targetDir);
+			Files.move(
+				targetFile,
+				targetDir.resolve(targetFile.getFileName()),
+				StandardCopyOption.REPLACE_EXISTING);
+			log.info("Moved file '{}' to '{}'", targetFile, targetDir);
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed to move processed files", e);
+		}
+	}
+
+	@Override
+	public void deletePreviouslyProcessedFile(Path processedFile) {
+		try {
+			if (Files.deleteIfExists(processedFile)) {
+				log.info("Old file deleted");
+			}
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed to delete file");
+		}
+	}
+
+	@Override
+	public void verifyReadable(Path path, String label) {
+		log.info("[{}] Checking file: {}", label, path.toAbsolutePath());
+
+		if (!Files.exists(path)) {
+			throw new IllegalStateException("File does not exist: " + path.toAbsolutePath());
+		}
+
+		if (!Files.isReadable(path)) {
+			throw new IllegalStateException("File not readable: " + path.toAbsolutePath());
+		}
+
+		try {
+			long size = Files.size(path);
+			String firstLine = Files.readAllLines(path, StandardCharsets.UTF_8).stream()
+				.findFirst()
+				.orElse("");
+			log.info("[{}] OK. Size={} bytes. First line: {}", label, size, firstLine);
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed reading file: " + path.toAbsolutePath(), e);
+		}
+	}
+}

--- a/src/main/java/se/sundsvall/csvfilereader/file/FileManager.java
+++ b/src/main/java/se/sundsvall/csvfilereader/file/FileManager.java
@@ -1,105 +1,13 @@
 package se.sundsvall.csvfilereader.file;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.FileSystemManager;
-import org.apache.commons.vfs2.FileSystemOptions;
-import org.apache.commons.vfs2.Selectors;
-import org.apache.commons.vfs2.VFS;
-import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.stereotype.Component;
 
-@Component
-@EnableConfigurationProperties(SftpProperties.class)
-public class FileManager {
+public interface FileManager {
+	void downloadFile(Path dir, String fileName);
 
-	private static final Logger log = LoggerFactory.getLogger(FileManager.class);
-	SftpProperties sftpProperties;
+	void moveFile(Path targetFile, Path targetDir);
 
-	public FileManager(SftpProperties sftpProperties) {
-		this.sftpProperties = sftpProperties;
-	}
+	void deletePreviouslyProcessedFile(Path processedFile);
 
-	public void downloadFile(Path dir, String fileName) {
-
-		try {
-			FileSystemManager manager = VFS.getManager();
-			FileSystemOptions options = new FileSystemOptions();
-
-			var builder = SftpFileSystemConfigBuilder.getInstance();
-			builder.setConnectTimeout(options, sftpProperties.connectTimeout());
-			builder.setSessionTimeout(options, sftpProperties.sessionTimeout());
-
-			var local = manager.resolveFile(dir.resolve(fileName).toUri().toString());
-			var remote = manager.resolveFile(String.format("sftp://%s:%s@%s/%s",
-				sftpProperties.username(),
-				sftpProperties.password(),
-				sftpProperties.remoteHost(),
-				fileName), options);
-
-			local.copyFrom(remote, Selectors.SELECT_SELF);
-			log.info("File '{}' downloaded", fileName);
-			local.close();
-			remote.close();
-
-		} catch (FileSystemException e) {
-			log.info("Error downloading file", e);
-		}
-	}
-
-	public void moveFile(Path targetFile, Path targetDir) {
-		try {
-			Files.createDirectories(targetDir);
-
-			Files.move(
-				targetFile,
-				targetDir.resolve(targetFile.getFileName()),
-				StandardCopyOption.REPLACE_EXISTING);
-
-			log.info("Moved file '{}' to '{}' after reading", targetFile, targetDir);
-		} catch (IOException e) {
-			throw new IllegalStateException("Failed to move processed files", e);
-		}
-	}
-
-	public void deletePreviouslyProcessedFile(Path processedFile) {
-		try {
-			if (Files.deleteIfExists(processedFile)) {
-				log.info("Old file deleted");
-			}
-		} catch (IOException e) {
-			throw new IllegalStateException("Failed to delete file");
-		}
-	}
-
-	public void verifyReadable(Path path, String label) {
-		log.info("[{}] Checking file: {}", label, path.toAbsolutePath());
-
-		if (!Files.exists(path)) {
-			throw new IllegalStateException("File does not exist: " + path.toAbsolutePath());
-		}
-
-		if (!Files.isReadable(path)) {
-			throw new IllegalStateException("File not readable: " + path.toAbsolutePath());
-		}
-
-		try {
-			long size = Files.size(path);
-			String firstLine = Files.readAllLines(path, StandardCharsets.UTF_8).stream()
-				.findFirst()
-				.orElse("");
-
-			log.info("[{}] OK. Size={} bytes. First line: {}", label, size, firstLine);
-
-		} catch (IOException e) {
-			throw new IllegalStateException("Failed reading file: " + path.toAbsolutePath(), e);
-		}
-	}
+	void verifyReadable(Path path, String label);
 }

--- a/src/main/java/se/sundsvall/csvfilereader/file/MockFileManager.java
+++ b/src/main/java/se/sundsvall/csvfilereader/file/MockFileManager.java
@@ -1,7 +1,6 @@
 package se.sundsvall.csvfilereader.file;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -13,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Profile("mock")
-public class MockFileManager implements FileManager {
+public class MockFileManager extends AbstractFileManager {
 
 	private static final Logger log = LoggerFactory.getLogger(MockFileManager.class);
 
@@ -31,54 +30,6 @@ public class MockFileManager implements FileManager {
 			log.info("Mock: copied file '{}' from temp to incoming", fileName);
 		} catch (IOException e) {
 			log.error("Mock: failed to copy file '{}'", fileName, e);
-		}
-	}
-
-	@Override
-	public void moveFile(Path targetFile, Path targetDir) {
-		try {
-			Files.createDirectories(targetDir);
-			Files.move(
-				targetFile,
-				targetDir.resolve(targetFile.getFileName()),
-				StandardCopyOption.REPLACE_EXISTING);
-			log.info("Moved file '{}' to '{}'", targetFile, targetDir);
-		} catch (IOException e) {
-			throw new IllegalStateException("Failed to move processed files", e);
-		}
-	}
-
-	@Override
-	public void deletePreviouslyProcessedFile(Path processedFile) {
-		try {
-			if (Files.deleteIfExists(processedFile)) {
-				log.info("Old file deleted");
-			}
-		} catch (IOException e) {
-			throw new IllegalStateException("Failed to delete file");
-		}
-	}
-
-	@Override
-	public void verifyReadable(Path path, String label) {
-		log.info("[{}] Checking file: {}", label, path.toAbsolutePath());
-
-		if (!Files.exists(path)) {
-			throw new IllegalStateException("File does not exist: " + path.toAbsolutePath());
-		}
-
-		if (!Files.isReadable(path)) {
-			throw new IllegalStateException("File not readable: " + path.toAbsolutePath());
-		}
-
-		try {
-			long size = Files.size(path);
-			String firstLine = Files.readAllLines(path, StandardCharsets.UTF_8).stream()
-				.findFirst()
-				.orElse("");
-			log.info("[{}] OK. Size={} bytes. First line: {}", label, size, firstLine);
-		} catch (IOException e) {
-			throw new IllegalStateException("Failed reading file: " + path.toAbsolutePath(), e);
 		}
 	}
 }

--- a/src/main/java/se/sundsvall/csvfilereader/file/MockFileManager.java
+++ b/src/main/java/se/sundsvall/csvfilereader/file/MockFileManager.java
@@ -1,0 +1,84 @@
+package se.sundsvall.csvfilereader.file;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("mock")
+public class MockFileManager implements FileManager {
+
+	private static final Logger log = LoggerFactory.getLogger(MockFileManager.class);
+
+	@Value("${import.file-source-dir}")
+	private Path fileSourceDir;
+
+	@Override
+	public void downloadFile(Path dir, String fileName) {
+		try {
+			Files.createDirectories(dir);
+			Files.copy(
+				fileSourceDir.resolve(fileName),
+				dir.resolve(fileName),
+				StandardCopyOption.REPLACE_EXISTING);
+			log.info("Mock: copied file '{}' from temp to incoming", fileName);
+		} catch (IOException e) {
+			log.error("Mock: failed to copy file '{}'", fileName, e);
+		}
+	}
+
+	@Override
+	public void moveFile(Path targetFile, Path targetDir) {
+		try {
+			Files.createDirectories(targetDir);
+			Files.move(
+				targetFile,
+				targetDir.resolve(targetFile.getFileName()),
+				StandardCopyOption.REPLACE_EXISTING);
+			log.info("Moved file '{}' to '{}'", targetFile, targetDir);
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed to move processed files", e);
+		}
+	}
+
+	@Override
+	public void deletePreviouslyProcessedFile(Path processedFile) {
+		try {
+			if (Files.deleteIfExists(processedFile)) {
+				log.info("Old file deleted");
+			}
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed to delete file");
+		}
+	}
+
+	@Override
+	public void verifyReadable(Path path, String label) {
+		log.info("[{}] Checking file: {}", label, path.toAbsolutePath());
+
+		if (!Files.exists(path)) {
+			throw new IllegalStateException("File does not exist: " + path.toAbsolutePath());
+		}
+
+		if (!Files.isReadable(path)) {
+			throw new IllegalStateException("File not readable: " + path.toAbsolutePath());
+		}
+
+		try {
+			long size = Files.size(path);
+			String firstLine = Files.readAllLines(path, StandardCharsets.UTF_8).stream()
+				.findFirst()
+				.orElse("");
+			log.info("[{}] OK. Size={} bytes. First line: {}", label, size, firstLine);
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed reading file: " + path.toAbsolutePath(), e);
+		}
+	}
+}

--- a/src/main/java/se/sundsvall/csvfilereader/file/SftpFileManager.java
+++ b/src/main/java/se/sundsvall/csvfilereader/file/SftpFileManager.java
@@ -1,0 +1,111 @@
+package se.sundsvall.csvfilereader.file;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!mock")
+@EnableConfigurationProperties(SftpProperties.class)
+public class SftpFileManager implements FileManager {
+
+	private static final Logger log = LoggerFactory.getLogger(SftpFileManager.class);
+	SftpProperties sftpProperties;
+
+	public SftpFileManager(SftpProperties sftpProperties) {
+		this.sftpProperties = sftpProperties;
+	}
+
+	@Override
+	public void downloadFile(Path dir, String fileName) {
+
+		try {
+			FileSystemManager manager = VFS.getManager();
+			FileSystemOptions options = new FileSystemOptions();
+
+			var builder = SftpFileSystemConfigBuilder.getInstance();
+			builder.setConnectTimeout(options, sftpProperties.connectTimeout());
+			builder.setSessionTimeout(options, sftpProperties.sessionTimeout());
+
+			var local = manager.resolveFile(dir.resolve(fileName).toUri().toString());
+			var remote = manager.resolveFile(String.format("sftp://%s:%s@%s/%s",
+				sftpProperties.username(),
+				sftpProperties.password(),
+				sftpProperties.remoteHost(),
+				fileName), options);
+
+			local.copyFrom(remote, Selectors.SELECT_SELF);
+			log.info("File '{}' downloaded", fileName);
+			local.close();
+			remote.close();
+
+		} catch (FileSystemException e) {
+			log.info("Error downloading file", e);
+		}
+	}
+
+	@Override
+	public void moveFile(Path targetFile, Path targetDir) {
+		try {
+			Files.createDirectories(targetDir);
+
+			Files.move(
+				targetFile,
+				targetDir.resolve(targetFile.getFileName()),
+				StandardCopyOption.REPLACE_EXISTING);
+
+			log.info("Moved file '{}' to '{}' after reading", targetFile, targetDir);
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed to move processed files", e);
+		}
+	}
+
+	@Override
+	public void deletePreviouslyProcessedFile(Path processedFile) {
+		try {
+			if (Files.deleteIfExists(processedFile)) {
+				log.info("Old file deleted");
+			}
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed to delete file");
+		}
+	}
+
+	@Override
+	public void verifyReadable(Path path, String label) {
+		log.info("[{}] Checking file: {}", label, path.toAbsolutePath());
+
+		if (!Files.exists(path)) {
+			throw new IllegalStateException("File does not exist: " + path.toAbsolutePath());
+		}
+
+		if (!Files.isReadable(path)) {
+			throw new IllegalStateException("File not readable: " + path.toAbsolutePath());
+		}
+
+		try {
+			long size = Files.size(path);
+			String firstLine = Files.readAllLines(path, StandardCharsets.UTF_8).stream()
+				.findFirst()
+				.orElse("");
+
+			log.info("[{}] OK. Size={} bytes. First line: {}", label, size, firstLine);
+
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed reading file: " + path.toAbsolutePath(), e);
+		}
+	}
+}

--- a/src/main/java/se/sundsvall/csvfilereader/file/SftpFileManager.java
+++ b/src/main/java/se/sundsvall/csvfilereader/file/SftpFileManager.java
@@ -1,10 +1,7 @@
 package se.sundsvall.csvfilereader.file;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.FileSystemOptions;
@@ -20,7 +17,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Profile("!mock")
 @EnableConfigurationProperties(SftpProperties.class)
-public class SftpFileManager implements FileManager {
+public class SftpFileManager extends AbstractFileManager {
 
 	private static final Logger log = LoggerFactory.getLogger(SftpFileManager.class);
 	SftpProperties sftpProperties;
@@ -31,7 +28,8 @@ public class SftpFileManager implements FileManager {
 
 	@Override
 	public void downloadFile(Path dir, String fileName) {
-
+		FileObject local = null;
+		FileObject remote = null;
 		try {
 			FileSystemManager manager = VFS.getManager();
 			FileSystemOptions options = new FileSystemOptions();
@@ -40,8 +38,8 @@ public class SftpFileManager implements FileManager {
 			builder.setConnectTimeout(options, sftpProperties.connectTimeout());
 			builder.setSessionTimeout(options, sftpProperties.sessionTimeout());
 
-			var local = manager.resolveFile(dir.resolve(fileName).toUri().toString());
-			var remote = manager.resolveFile(String.format("sftp://%s:%s@%s/%s",
+			local = manager.resolveFile(dir.resolve(fileName).toUri().toString());
+			remote = manager.resolveFile(String.format("sftp://%s:%s@%s/%s",
 				sftpProperties.username(),
 				sftpProperties.password(),
 				sftpProperties.remoteHost(),
@@ -49,63 +47,24 @@ public class SftpFileManager implements FileManager {
 
 			local.copyFrom(remote, Selectors.SELECT_SELF);
 			log.info("File '{}' downloaded", fileName);
-			local.close();
-			remote.close();
 
 		} catch (FileSystemException e) {
 			log.info("Error downloading file", e);
-		}
-	}
-
-	@Override
-	public void moveFile(Path targetFile, Path targetDir) {
-		try {
-			Files.createDirectories(targetDir);
-
-			Files.move(
-				targetFile,
-				targetDir.resolve(targetFile.getFileName()),
-				StandardCopyOption.REPLACE_EXISTING);
-
-			log.info("Moved file '{}' to '{}' after reading", targetFile, targetDir);
-		} catch (IOException e) {
-			throw new IllegalStateException("Failed to move processed files", e);
-		}
-	}
-
-	@Override
-	public void deletePreviouslyProcessedFile(Path processedFile) {
-		try {
-			if (Files.deleteIfExists(processedFile)) {
-				log.info("Old file deleted");
+		} finally {
+			if (local != null) {
+				try {
+					local.close();
+				} catch (FileSystemException e) {
+					log.warn("Failed to close local file", e);
+				}
 			}
-		} catch (IOException e) {
-			throw new IllegalStateException("Failed to delete file");
-		}
-	}
-
-	@Override
-	public void verifyReadable(Path path, String label) {
-		log.info("[{}] Checking file: {}", label, path.toAbsolutePath());
-
-		if (!Files.exists(path)) {
-			throw new IllegalStateException("File does not exist: " + path.toAbsolutePath());
-		}
-
-		if (!Files.isReadable(path)) {
-			throw new IllegalStateException("File not readable: " + path.toAbsolutePath());
-		}
-
-		try {
-			long size = Files.size(path);
-			String firstLine = Files.readAllLines(path, StandardCharsets.UTF_8).stream()
-				.findFirst()
-				.orElse("");
-
-			log.info("[{}] OK. Size={} bytes. First line: {}", label, size, firstLine);
-
-		} catch (IOException e) {
-			throw new IllegalStateException("Failed reading file: " + path.toAbsolutePath(), e);
+			if (remote != null) {
+				try {
+					remote.close();
+				} catch (FileSystemException e) {
+					log.warn("Failed to close remote file", e);
+				}
+			}
 		}
 	}
 }

--- a/src/main/java/se/sundsvall/csvfilereader/scheduler/Scheduler.java
+++ b/src/main/java/se/sundsvall/csvfilereader/scheduler/Scheduler.java
@@ -13,8 +13,6 @@ import se.sundsvall.dept44.scheduling.Dept44Scheduled;
 @Configuration
 public class Scheduler {
 
-	@Value("${import.file-source-dir}")
-	private Path fileSourceDir;
 	@Value("${import.incoming-dir}")
 	private Path incomingDir;
 	@Value("${import.processed-dir}")

--- a/src/test/java/se/sundsvall/csvfilereader/file/AbstractFileManagerTest.java
+++ b/src/test/java/se/sundsvall/csvfilereader/file/AbstractFileManagerTest.java
@@ -1,0 +1,132 @@
+package se.sundsvall.csvfilereader.file;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AbstractFileManagerTest {
+
+	@TempDir
+	Path tempDir;
+
+	private AbstractFileManager fileManager;
+
+	@BeforeEach
+	void setUp() {
+		fileManager = new AbstractFileManager() {
+			@Override
+			public void downloadFile(Path dir, String fileName) {
+				// Tested in Sftp and MockFileManagerTest
+			}
+		};
+	}
+
+	@Test
+	void testMoveOrganizationFiles() throws IOException {
+		Path sourceDir = tempDir.resolve("incoming");
+		Path targetDir = tempDir.resolve("processed");
+		Files.createDirectories(sourceDir);
+		String content = "string";
+
+		Path orgCsv = sourceDir.resolve("OrgExport.csv");
+		Files.writeString(orgCsv, content);
+
+		fileManager.moveFile(orgCsv, targetDir);
+
+		Path moved = targetDir.resolve("OrgExport.csv");
+		assertTrue(Files.exists(moved));
+		assertFalse(Files.exists(orgCsv));
+		assertEquals(content, Files.readString(moved));
+	}
+
+	@Test
+	void testMoveEmployeeFiles() throws IOException {
+		Path sourceDir = tempDir.resolve("incoming");
+		Path targetDir = tempDir.resolve("processed");
+		Files.createDirectories(sourceDir);
+		Files.createDirectories(targetDir);
+		String content = "string";
+
+		Path empCsv = sourceDir.resolve("EmpExport.csv");
+		Files.writeString(empCsv, content);
+
+		fileManager.moveFile(empCsv, targetDir);
+
+		Path moved = targetDir.resolve("EmpExport.csv");
+		assertTrue(Files.exists(moved));
+		assertFalse(Files.exists(empCsv));
+		assertEquals(content, Files.readString(moved));
+	}
+
+	@Test
+	void testMoveFile_whenTargetDirIsAFile_shouldThrowIllegalStateException() throws IOException {
+		Path incomingDir = tempDir.resolve("incoming");
+		Files.createDirectories(incomingDir);
+
+		Path filePath = incomingDir.resolve("OrgExport.csv");
+		Files.writeString(filePath, "string");
+
+		Path processedDir = tempDir.resolve("processed");
+		Files.writeString(processedDir, "file");
+
+		assertThrows(IllegalStateException.class, () -> fileManager.moveFile(filePath, processedDir));
+	}
+
+	@Test
+	void testDeletePreviouslyProcessedFile() throws IOException {
+		Path processed = tempDir.resolve("processed.csv");
+		Files.writeString(processed, "string");
+		assertTrue(Files.exists(processed));
+
+		fileManager.deletePreviouslyProcessedFile(processed);
+
+		assertFalse(Files.exists(processed));
+	}
+
+	@Test
+	void deleteProcessedFileWhenFileDoesNotExistTest() throws IOException {
+		Path dir = tempDir.resolve("dir");
+		Files.createDirectory(dir);
+		Files.writeString(dir.resolve("file.txt"), "test");
+
+		IllegalStateException ex = assertThrows(
+			IllegalStateException.class,
+			() -> fileManager.deletePreviouslyProcessedFile(dir));
+
+		assertEquals("Failed to delete file", ex.getMessage());
+	}
+
+	@Test
+	void verifyReadableWhenNoFileTest() {
+		Path missingFile = tempDir.resolve("missing.csv");
+
+		IllegalStateException exception = assertThrows(
+			IllegalStateException.class, () -> fileManager.verifyReadable(missingFile, "ORG"));
+
+		assertTrue(exception.getMessage().startsWith("File does not exist:"));
+	}
+
+	@Test
+	void verifyReadable_whenFileExists_doesNotThrow() throws IOException {
+		Path file = tempDir.resolve("OrgExport.csv");
+		Files.writeString(file, "string");
+
+		assertDoesNotThrow(() -> fileManager.verifyReadable(file, "ORG"));
+	}
+
+	@Test
+	void verifyReadable_throwsException() throws IOException {
+		Path directory = tempDir.resolve("directory");
+		Files.createDirectory(directory);
+
+		IllegalStateException exception = assertThrows(
+			IllegalStateException.class, () -> fileManager.verifyReadable(directory, "ORG"));
+
+		assertTrue(exception.getMessage().startsWith("Failed reading file:"));
+	}
+}

--- a/src/test/java/se/sundsvall/csvfilereader/file/MockFileManagerTest.java
+++ b/src/test/java/se/sundsvall/csvfilereader/file/MockFileManagerTest.java
@@ -1,0 +1,48 @@
+package se.sundsvall.csvfilereader.file;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MockFileManagerTest {
+
+	@TempDir
+	Path tempDir;
+
+	private MockFileManager mockFileManager;
+
+	@BeforeEach
+	void setUp() {
+		mockFileManager = new MockFileManager();
+		ReflectionTestUtils.setField(mockFileManager, "fileSourceDir", tempDir.resolve("temp"));
+	}
+
+	@Test
+	void downloadFile_copiesFileFromTempToIncoming() throws IOException {
+		Path tempSource = tempDir.resolve("temp");
+		Path incomingDir = tempDir.resolve("incoming");
+		Files.createDirectories(tempSource);
+
+		String content = "col1;col2\nval1;val2";
+		Files.writeString(tempSource.resolve("OrgExport.csv"), content);
+
+		mockFileManager.downloadFile(incomingDir, "OrgExport.csv");
+
+		Path copied = incomingDir.resolve("OrgExport.csv");
+		assertTrue(Files.exists(copied));
+		assertEquals(content, Files.readString(copied));
+	}
+
+	@Test
+	void downloadFile_whenSourceFileMissing_doesNotThrow() {
+		Path incomingDir = tempDir.resolve("incoming");
+
+		assertDoesNotThrow(() -> mockFileManager.downloadFile(incomingDir, "missing.csv"));
+	}
+}

--- a/src/test/java/se/sundsvall/csvfilereader/file/SftpFileManagerTest.java
+++ b/src/test/java/se/sundsvall/csvfilereader/file/SftpFileManagerTest.java
@@ -1,7 +1,5 @@
 package se.sundsvall.csvfilereader.file;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
@@ -11,7 +9,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +26,6 @@ class SftpFileManagerTest {
 
 	@Test
 	void downloadFileTest() {
-
 		Path incomingDir = tempDir.resolve("incoming");
 		String fileName = "file.csv";
 
@@ -40,128 +36,11 @@ class SftpFileManagerTest {
 		when(sftpProperties.sessionTimeout()).thenReturn(Duration.ofSeconds(15));
 
 		sftpFileManager.downloadFile(incomingDir, fileName);
+
 		verify(sftpProperties).username();
 		verify(sftpProperties).password();
 		verify(sftpProperties).remoteHost();
 		verify(sftpProperties).connectTimeout();
 		verify(sftpProperties).sessionTimeout();
-	}
-
-	@Test
-	void testMoveOrganizationFiles() throws IOException {
-		// Arrange
-		Path sourceDir = tempDir.resolve("incoming");
-		Path targetDir = tempDir.resolve("processed");
-		Files.createDirectories(sourceDir);
-		String content = "string";
-
-		Path orgCsv = sourceDir.resolve("OrgExport.csv");
-		Files.writeString(orgCsv, content);
-		// Act
-		sftpFileManager.moveFile(orgCsv, targetDir);
-		// Assert
-		Path moved = targetDir.resolve("OrgExport.csv");
-		assertTrue(Files.exists(moved), "expected file to exist");
-		assertFalse(Files.exists(orgCsv), "expected file to be moved");
-
-		assertEquals(content, Files.readString(moved));
-	}
-
-	@Test
-	void testMoveEmployeeFiles() throws IOException {
-		// Arrange
-		Path sourceDir = tempDir.resolve("incoming");
-		Path targetDir = tempDir.resolve("processed");
-		Files.createDirectories(sourceDir);
-		Files.createDirectories(targetDir);
-
-		String content = "string";
-
-		Path empCsv = sourceDir.resolve("EmpExport.csv");
-		Files.writeString(empCsv, content);
-		// Act
-		sftpFileManager.moveFile(empCsv, targetDir);
-		// Assert
-		Path moved = targetDir.resolve("EmpExport.csv");
-		assertTrue(Files.exists(moved), "expected file to exist");
-		assertFalse(Files.exists(empCsv), "expected file to be moved");
-
-		assertEquals(content, Files.readString(moved));
-
-	}
-
-	@Test
-	void testDeletePreviouslyProcessedFile() throws IOException {
-		// Arrange
-		Path processed = tempDir.resolve("processed.csv");
-		Files.writeString(processed, "string");
-		assertTrue(Files.exists(processed), "not deleted");
-		// Act
-		sftpFileManager.deletePreviouslyProcessedFile(processed);
-		// Assert
-		assertFalse(Files.exists(processed), "expected to be deleted");
-	}
-
-	@Test
-	void deleteProcessedFileWhenFileDoesNotExistTest() throws IOException {
-		// Arrange
-		Path dir = tempDir.resolve("dir");
-		Files.createDirectory(dir);
-
-		Files.writeString(dir.resolve("file.txt"), "test");
-
-		// Act
-		IllegalStateException ex = assertThrows(
-			IllegalStateException.class,
-			() -> sftpFileManager.deletePreviouslyProcessedFile(dir));
-
-		// Assert
-		assertEquals("Failed to delete file", ex.getMessage());
-	}
-
-	@Test
-	void testMoveFile_whenTargetDirIsAFile_shouldThrowIllegalStateException() throws IOException {
-		Path incomingDir = tempDir.resolve("incoming");
-		Files.createDirectories(incomingDir);
-
-		Path filePath = incomingDir.resolve("OrgExport.csv");
-		Files.writeString(filePath, "string");
-
-		Path processedDir = tempDir.resolve("processed");
-		Files.writeString(processedDir, "file");
-		assertTrue(Files.isRegularFile(processedDir));
-
-		assertThrows(IllegalStateException.class, () -> sftpFileManager.moveFile(filePath, processedDir));
-	}
-
-	@Test
-	void verifyReadableWhenNoFileTest() {
-
-		Path missingFile = tempDir.resolve("missing.csv");
-
-		IllegalStateException exception = assertThrows(
-			IllegalStateException.class, () -> sftpFileManager.verifyReadable(missingFile, "ORG"));
-
-		assertTrue(exception.getMessage().startsWith("File does not exist:"));
-	}
-
-	@Test
-	void verifyReadable_whenFileExists_doesNotThrow() throws Exception {
-		Path file = tempDir.resolve("OrgExport.csv");
-
-		Files.writeString(file, "string");
-
-		assertDoesNotThrow(() -> sftpFileManager.verifyReadable(file, "ORG"));
-	}
-
-	@Test
-	void verifyReadable_throwsException() throws IOException {
-		Path directory = tempDir.resolve("directory");
-		Files.createDirectory(directory);
-
-		IllegalStateException exception = assertThrows(
-			IllegalStateException.class, () -> sftpFileManager.verifyReadable(directory, "ORG"));
-
-		assertTrue(exception.getMessage().startsWith("Failed reading file:"));
 	}
 }

--- a/src/test/java/se/sundsvall/csvfilereader/file/SftpFileManagerTest.java
+++ b/src/test/java/se/sundsvall/csvfilereader/file/SftpFileManagerTest.java
@@ -16,13 +16,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class FileManagerTest {
+public class SftpFileManagerTest {
 
 	@Mock
 	private SftpProperties sftpProperties;
 
 	@InjectMocks
-	private FileManager fileManager;
+	private SftpFileManager sftpFileManager;
 
 	@TempDir
 	Path tempDir;
@@ -39,7 +39,7 @@ public class FileManagerTest {
 		when(sftpProperties.connectTimeout()).thenReturn(Duration.ofSeconds(15));
 		when(sftpProperties.sessionTimeout()).thenReturn(Duration.ofSeconds(15));
 
-		fileManager.downloadFile(incomingDir, fileName);
+		sftpFileManager.downloadFile(incomingDir, fileName);
 		verify(sftpProperties).username();
 		verify(sftpProperties).password();
 		verify(sftpProperties).remoteHost();
@@ -58,7 +58,7 @@ public class FileManagerTest {
 		Path orgCsv = sourceDir.resolve("OrgExport.csv");
 		Files.writeString(orgCsv, content);
 		// Act
-		fileManager.moveFile(orgCsv, targetDir);
+		sftpFileManager.moveFile(orgCsv, targetDir);
 		// Assert
 		Path moved = targetDir.resolve("OrgExport.csv");
 		assertTrue(Files.exists(moved), "expected file to exist");
@@ -80,7 +80,7 @@ public class FileManagerTest {
 		Path empCsv = sourceDir.resolve("EmpExport.csv");
 		Files.writeString(empCsv, content);
 		// Act
-		fileManager.moveFile(empCsv, targetDir);
+		sftpFileManager.moveFile(empCsv, targetDir);
 		// Assert
 		Path moved = targetDir.resolve("EmpExport.csv");
 		assertTrue(Files.exists(moved), "expected file to exist");
@@ -97,7 +97,7 @@ public class FileManagerTest {
 		Files.writeString(processed, "string");
 		assertTrue(Files.exists(processed), "not deleted");
 		// Act
-		fileManager.deletePreviouslyProcessedFile(processed);
+		sftpFileManager.deletePreviouslyProcessedFile(processed);
 		// Assert
 		assertFalse(Files.exists(processed), "expected to be deleted");
 	}
@@ -113,7 +113,7 @@ public class FileManagerTest {
 		// Act
 		IllegalStateException ex = assertThrows(
 			IllegalStateException.class,
-			() -> fileManager.deletePreviouslyProcessedFile(dir));
+			() -> sftpFileManager.deletePreviouslyProcessedFile(dir));
 
 		// Assert
 		assertEquals("Failed to delete file", ex.getMessage());
@@ -131,7 +131,7 @@ public class FileManagerTest {
 		Files.writeString(processedDir, "file");
 		assertTrue(Files.isRegularFile(processedDir));
 
-		assertThrows(IllegalStateException.class, () -> fileManager.moveFile(filePath, processedDir));
+		assertThrows(IllegalStateException.class, () -> sftpFileManager.moveFile(filePath, processedDir));
 	}
 
 	@Test
@@ -140,7 +140,7 @@ public class FileManagerTest {
 		Path missingFile = tempDir.resolve("missing.csv");
 
 		IllegalStateException exception = assertThrows(
-			IllegalStateException.class, () -> fileManager.verifyReadable(missingFile, "ORG"));
+			IllegalStateException.class, () -> sftpFileManager.verifyReadable(missingFile, "ORG"));
 
 		assertTrue(exception.getMessage().startsWith("File does not exist:"));
 	}
@@ -151,7 +151,7 @@ public class FileManagerTest {
 
 		Files.writeString(file, "string");
 
-		assertDoesNotThrow(() -> fileManager.verifyReadable(file, "ORG"));
+		assertDoesNotThrow(() -> sftpFileManager.verifyReadable(file, "ORG"));
 	}
 
 	@Test
@@ -160,7 +160,7 @@ public class FileManagerTest {
 		Files.createDirectory(directory);
 
 		IllegalStateException exception = assertThrows(
-			IllegalStateException.class, () -> fileManager.verifyReadable(directory, "ORG"));
+			IllegalStateException.class, () -> sftpFileManager.verifyReadable(directory, "ORG"));
 
 		assertTrue(exception.getMessage().startsWith("Failed reading file:"));
 	}

--- a/src/test/java/se/sundsvall/csvfilereader/file/SftpFileManagerTest.java
+++ b/src/test/java/se/sundsvall/csvfilereader/file/SftpFileManagerTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class SftpFileManagerTest {
+class SftpFileManagerTest {
 
 	@Mock
 	private SftpProperties sftpProperties;

--- a/src/test/java/se/sundsvall/csvfilereader/scheduler/SchedulerTest.java
+++ b/src/test/java/se/sundsvall/csvfilereader/scheduler/SchedulerTest.java
@@ -31,20 +31,14 @@ public class SchedulerTest {
 
 		Scheduler scheduler = new Scheduler(employeeImportService, organizationImportService, fileManager);
 
-		Path fileSourceDir = tempDir.resolve("file_source");
 		Path incomingDir = tempDir.resolve("incoming");
 		Path processedDir = tempDir.resolve("processed");
 
-		Files.createDirectories(fileSourceDir);
 		Files.createDirectories(incomingDir);
 		Files.createDirectories(processedDir);
 
 		String orgCsv = "org.csv";
 
-		Path orgCsvPath = fileSourceDir.resolve(orgCsv);
-		Files.writeString(orgCsvPath, "CompanyId,OrgId,OrgName,ParentId,TreeLevel\n1,A,Root,,0\n");
-
-		setField(scheduler, "fileSourceDir", fileSourceDir);
 		setField(scheduler, "incomingDir", incomingDir);
 		setField(scheduler, "processedDir", processedDir);
 		setField(scheduler, "orgFileName", orgCsv);
@@ -69,20 +63,14 @@ public class SchedulerTest {
 
 		Scheduler scheduler = new Scheduler(employeeImportService, organizationImportService, fileManager);
 
-		Path fileSourceDir = tempDir.resolve("file_source");
 		Path incomingDir = tempDir.resolve("incoming");
 		Path processedDir = tempDir.resolve("processed");
 
-		Files.createDirectories(fileSourceDir);
 		Files.createDirectories(incomingDir);
 		Files.createDirectories(processedDir);
 
 		String empCsv = "emp.csv";
 
-		Path empCsvPath = fileSourceDir.resolve(empCsv);
-		Files.writeString(empCsvPath, "PersonId;Givenname;Lastname;123;Alice;Andersson");
-
-		setField(scheduler, "fileSourceDir", fileSourceDir);
 		setField(scheduler, "incomingDir", incomingDir);
 		setField(scheduler, "processedDir", processedDir);
 		setField(scheduler, "empFileName", empCsv);
@@ -106,17 +94,12 @@ public class SchedulerTest {
 
 		Scheduler scheduler = new Scheduler(employeeImportService, organizationImportService, fileManager);
 
-		Path fileSourceDir = tempDir.resolve("file_source");
 		Path incomingDir = tempDir.resolve("incoming");
 		Path processedDir = tempDir.resolve("processed");
 
-		Files.createDirectories(fileSourceDir);
 		Files.createDirectories(incomingDir);
 		Files.createDirectories(processedDir);
 
-		Files.writeString(tempDir.resolve(fileSourceDir).resolve("emp.csv"), "test");
-
-		setField(scheduler, "fileSourceDir", fileSourceDir);
 		setField(scheduler, "incomingDir", incomingDir);
 		setField(scheduler, "processedDir", processedDir);
 		setField(scheduler, "empFileName", "emp.csv");
@@ -136,17 +119,12 @@ public class SchedulerTest {
 
 		Scheduler scheduler = new Scheduler(employeeImportService, organizationImportService, fileManager);
 
-		Path fileSourceDir = tempDir.resolve("file_source");
 		Path incomingDir = tempDir.resolve("incoming");
 		Path processedDir = tempDir.resolve("processed");
 
-		Files.createDirectories(fileSourceDir);
 		Files.createDirectories(incomingDir);
 		Files.createDirectories(processedDir);
 
-		Files.writeString(tempDir.resolve(fileSourceDir).resolve("org.csv"), "test");
-
-		setField(scheduler, "fileSourceDir", fileSourceDir);
 		setField(scheduler, "incomingDir", incomingDir);
 		setField(scheduler, "processedDir", processedDir);
 		setField(scheduler, "orgFileName", "org.csv");


### PR DESCRIPTION
Introduces a FileManager interface with two implementations:
- SftpFileManager (@Profile("!mock")) - existing SFTP logic for production
- MockFileManager (@Profile("mock")) - copies files from /data/temp for mock environment

Scheduler and SchedulerTest updated to use the FileManager interface.

Fixes issue #24  - the service could not run in a mock environment without a real SFTP server.